### PR TITLE
Initial build v1.20.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,6 +89,13 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Intel(R) level zero libraries
+  description: |
+    The objective of the ‘oneAPI’ Level-Zero Application Programming Interface (API) is to provide direct-to-metal
+    interfaces to offload accelerator devices. Its programming interface can be tailored to any device needs and can
+    be adapted to support broader set of languages features such as function pointers, virtual functions, unified
+    memory, and I/O capabilities.
+  dev_url: https://github.com/oneapi-src/level-zero
+  doc_url: https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/INTRO.html
 
 extra:
   feedstock-name: level-zero

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - {{ stdlib("c") }}
     - cmake
     - ninja
     - mako
@@ -31,7 +30,6 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - {{ stdlib("c") }}
     about:
       home: https://github.com/oneapi-src/level-zero
       license: MIT
@@ -61,7 +59,6 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - {{ stdlib("c") }}
       run:
         - {{ pin_subpackage('level-zero', exact=True) }}
     about:


### PR DESCRIPTION
level-zero 1.20.2

**Destination channel:** defaults

### Links

- [PKG-6980](https://anaconda.atlassian.net/browse/PKG-6980)
- [Upstream repository](https://github.com/oneapi-src/level-zero/tree/v1.20.2)
- [Upstream changelog/diff](https://github.com/oneapi-src/level-zero/blob/v1.20.2/CHANGELOG.md)
- Relevant dependency PRs:
  - AnacondaRecipes/intel-compilers-repack-feedstock#11

### Explanation of changes:

- Initial build of package from conda-forge fork


[PKG-6980]: https://anaconda.atlassian.net/browse/PKG-6980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ